### PR TITLE
Spotify status icon adjustment

### DIFF
--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -212,3 +212,6 @@
 .banner-1YaD3N.popoutBannerPremium-3i5EEI.bannerPremium-kkSkPv {
 	width: 250px;
 }
+.platformIcon-k3yytQ {
+	padding-right: 10px;
+}


### PR DESCRIPTION
Not sure is it only for me, if not this adjustment may work fine.

Before:
![image](https://user-images.githubusercontent.com/19209715/149399209-114baa51-b530-4bde-a18a-74bebbe8201f.png)
After:
![image](https://user-images.githubusercontent.com/19209715/149399427-30739999-14de-4e4c-b024-59e09b084188.png)
Original:
![image](https://user-images.githubusercontent.com/19209715/149399537-c46b0b9a-c3e8-4fe5-822c-fa22c32d10b7.png)
