### PR TITLE
Tweaks for the Profile Popout

### DIFF
--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -282,6 +282,7 @@ div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPosit
 }*/
 .customStatusText-2bcbbm {
 	text-align: center;
+	display: block;
 }
 header .bannerSVGWrapper-qc0szY {
 	display: grid;

--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -221,6 +221,7 @@
 
 .usernameSection-2d814A {
 	padding-top: 100px;
+	padding-bottom: 10px;
 }
 .userProfileInnerThemedNonPremium-1gT-zY {
 	background-color: #7189da !important;
@@ -239,6 +240,17 @@
 .usernameSection-2d814A,
 .customStatusSection-2TRu5f {
 	background-color: #202225;
+}
+
+/* removes dark circle behind status icon for profiles with custom colours */
+div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPositionPremiumBanner-2nq2Fy > div > div > svg > circle {
+	display: none;
+}
+
+.customStatusSection-2TRu5f {
+	max-height: calc(100vh - 20px);
+	padding-top: 0px;
+	padding-bottom: 5px;
 }
 
 .userPopoutOuter-3AVBmJ {
@@ -268,6 +280,9 @@
 .customStatusText-2bcbbm {
 	padding-bottom: 10px;
 }*/
+.customStatusText-2bcbbm {
+	text-align: center;
+}
 header .bannerSVGWrapper-qc0szY {
 	display: grid;
 }

--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -243,7 +243,8 @@
 }
 
 /* removes dark circle behind status icon for profiles with custom colours */
-div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPositionPremiumBanner-2nq2Fy > div > div > svg > circle {
+div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPositionPremiumBanner-2nq2Fy > div > div > svg > circle,
+div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPositionPremiumBanner-2nq2Fy > div > div > svg > rect:nth-child(2) {
 	display: none;
 }
 


### PR DESCRIPTION
makes the username and status not so close to the bottom of the dark gray area, also removes the dark circle around the status icon if the profile has custom colours (very specific i know lmao)

Before: ![Before Preview](https://i.imgur.com/Bn65rOd.png)

After: ![After Preview](https://i.imgur.com/k4Ugyic.png)