### PR TITLE
Make Profile Status Centered and Fixes Some Things

### DIFF
--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -281,9 +281,9 @@ div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPosit
 	top: 15px;
 }
 
-.customStatusText-2bcbbm {
-	text-align: center;
-	display: block;
+.customStatus-3Bvsdb {
+	justify-content: center;
+	display: flex;
 }
 header .bannerSVGWrapper-qc0szY {
 	display: grid;

--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -256,7 +256,7 @@ div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPosit
 .customStatusSection-2TRu5f {
 	max-height: calc(100vh - 20px);
 	padding-top: 0px;
-	padding-bottom: 5px;
+	padding-bottom: 10px;
 }
 
 .userPopoutOuter-3AVBmJ {
@@ -279,6 +279,11 @@ div.clickable-3iBWTO.avatarWrapperNormal-1tQ3Je.avatarWrapper-3y0KZ1.avatarPosit
 
 .avatarPositionPremiumBanner-2nq2Fy {
 	top: 15px;
+}
+
+/* fix message border still having custom colours */
+div {
+	--profile-message-input-border-color: transparent;
 }
 
 .customStatus-3Bvsdb {


### PR DESCRIPTION
profile statuses, including ones with or without emojis, are now properly centered. I also tweaked the padding of the status just a bit so it doesn't appear very close to the bottom.

also, I fixed the bug where if a profile had custom colours, the "message" box still had its custom border colour.